### PR TITLE
FIX - Site typos and omissions

### DIFF
--- a/SITE_BASE.md
+++ b/SITE_BASE.md
@@ -4,4 +4,4 @@ title: E-ARK Submission Information Package
 
 !TOC
 
-!INCLUDE "specification/E-ARK-SIP_specification-v2.0.0-DRAFT.md"
+!INCLUDE "specification/E-ARK-SIP_specification-v2.0.md"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins
+gem "jekyll-theme-primer", group: :jekyll_plugin

--- a/profile/E-ARK-SIP.xml
+++ b/profile/E-ARK-SIP.xml
@@ -10,11 +10,11 @@
     xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd"
     STATUS="provisional"
     REGISTRATION="unregistered"
-    ID="SIPV2.0.0-DRAFT">
+    ID="SIPV2.0.1">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earksip.dilcis.eu/profile/E-ARK-SIP.xml</URI>
-    <title>E-ARK SIP METS Profile 2.0</title>
-    <abstract>This is the extension of the E-ARK CS IP profile for creation of a E-ARK SIP.</abstract>
-    <date>2018-11-28T15:00:00</date>
+    <title>E-ARK SIP METS Profile</title>
+    <abstract>This is the extension of the E-ARK CSIP profile for creation of a E-ARK SIP.</abstract>
+    <date>2019-09-04T15:00:00</date>
     <contact>
         <institution>DILCIS Board</institution>
         <address>http://dilcis.eu/</address>
@@ -29,7 +29,7 @@
     </profile_context>
     <external_schema>
         <name>E-ARK SIP METS Extension</name>
-            <URL>https://dilcis.eu/XML/METS/SIPExtensionMETS/DILCISExtensionSIPMETS.xsd</URL>
+            <URL>http://earksip.dilcis.eu/schema/DILCISExtensionSIPMETS.xsd</URL>
             <context>XML-schema for the attributes added by SIP</context>
             <note>
                 <p xmlns="http://www.w3.org/1999/xhtml">An extension schema with the added attributes for use in this profile.</p>

--- a/specification/E-ARK-SIP_specification-v2.0.md
+++ b/specification/E-ARK-SIP_specification-v2.0.md
@@ -255,22 +255,17 @@ The following list of semantic elements provide a starting point for anyone will
 	* **Risk Factor** - Meant for listing all risk factors (e.g. the designated community is not properly defined) of the submission.
 	* **Mitigation Option** - Meant for listing all mitigation options (e.g. define the designated community together with producers) for the risks.
 
-
 ## Appendix B: E-ARK Information Package METS example
-
 
 !INCLUDE "appendices/examples/examples.md"
 
-
-## Appendix C: External Schema
+## Appendix C: External Schema and Vocabularies
 
 !INCLUDE "appendices/schema/schema.md"
-
 
 ## Appendix E: A Full List of E-ARK SIP Requirements
 
 !INCLUDE "appendices/requirements/requirements.md"
-
 
 # Glossary
 

--- a/specification/metadata.md
+++ b/specification/metadata.md
@@ -1,18 +1,9 @@
 ---
-title: E-ARK CSIP
-subtitle: Common Specification for Information Packages
+title: E-ARK SIP
+subtitle: Specification for Submission Information Packages
 abstract: |
-        This base profile describes the Common Specification for Information
-        Packages (CSIP) and the implementation of METS for packaging OAIS
-        conformant Information Packages. The profile is accompanied with a
-        textual document explaining the details of use of this profile.
-        This will enable repository interoperability and assist in the
-        management of the preservation of digital content.
-        This profile is a base profile which is extended with E-ARK
-        implementation of SIP, AIP and DIP. The profile can be used as is, but
-        it is recommended that the supplied extending implementation are used.
-        Alternatively, an own extension fulfilling the extending needs of the
-        implementer can be created.
+        This is the extension of the E-ARK CSIP profile for creation of an
+        E-ARK SIP.
 version: 2.0.1
-date: 15.07.2019
+date: 04.09.2019
 ---

--- a/specification/postface/postface.md
+++ b/specification/postface/postface.md
@@ -1,5 +1,8 @@
+
 # Postface
 
 !INCLUDE "authors.md"
 
 !INCLUDE "revisions.md"
+
+!INCLUDE "ack-contact.md"


### PR DESCRIPTION
- renamed specification document;
- update profile version number;
- removed version number from profile title;
- fixed extension schema path;
- fixed title, sub-title abstract;
- updated publication date; and
- add Gemfile for local site production.