### PR TITLE
Fixed typo REPLEACEMENT --> REPLACEMENT

### DIFF
--- a/schema/DILCISVocabulariesSIP.xml
+++ b/schema/DILCISVocabulariesSIP.xml
@@ -14,7 +14,7 @@
             <Definition>Extends the previous delivery.</Definition>
         </Entry>
         <Entry>
-            <Term lang="en">REPLEACEMENT</Term>
+            <Term lang="en">REPLACEMENT</Term>
             <Definition>Replaces a previous delivery.</Definition>
         </Entry>
         <Entry>

--- a/schema/DILCISVocabulariesSIP.xml
+++ b/schema/DILCISVocabulariesSIP.xml
@@ -18,7 +18,7 @@
             <Definition>Replaces a previous delivery.</Definition>
         </Entry>
         <Entry>
-            <Term lang="eb">TEST</Term>
+            <Term lang="en">TEST</Term>
             <Definition>A test delivery. No AIP should be created.</Definition>
         </Entry>
         <Entry>


### PR DESCRIPTION
I suspect that this is a typo and not part of the official vocabulary terminology.