### PR TITLE
FIX: Minor last minuters

### DIFF
--- a/archive/index.md
+++ b/archive/index.md
@@ -1,12 +1,11 @@
 ---
 title: Archived Versions of the SIP Specification
 ---
-
 # Archived Versions of the SIP Specification
 
 ## Latest
 
-[PDF Version 2.2.0](/pdf/eark-sip.pdf) 17-03-2024
+[PDF Version 2.2.0](/pdf/eark-sip.pdf) 17-05-2024
 
 ## Archived Versions
 

--- a/schema/index.md
+++ b/schema/index.md
@@ -1,19 +1,18 @@
 ---
 title: SIP Associated Schema Files
 ---
-SIP Associated Schema Files
-=======================
+# SIP Associated Schema Files
 
 - [METS XSD Schema](./mets.xsd)
   Version 1.12 of the METS schema
 - [DILCIS METS Extensions](./DILCISExtensionSIPMETS.xsd)
   Enumerated restrictions and types for attributes:
-  + `CONTENTINFORMATIONTYPE`
-  + `OTHERCONTENTTYPESPECIFICATION`
-  + `OAISPACKAGETYPE`
-  + `NOTETYPE`
+  - `CONTENTINFORMATIONTYPE`
+  - `OTHERCONTENTTYPESPECIFICATION`
+  - `OAISPACKAGETYPE`
+  - `NOTETYPE`
 - [RELAX grammer for describing vocabularies](DILCISVocabularies.rng)
   Used for vocabulary definitions below.
 - [DILCIS SIP Vocabulary Definitions](./DILCISVocabulariesSIP.xml)
   Fixed vocabularies for:
-  + `RECORDSTATUS`
+  - [`RECORDSTATUS`](./SIPVocabularyRecordStatus.xml)

--- a/site/_data/navbar.yml
+++ b/site/_data/navbar.yml
@@ -7,6 +7,9 @@
 - title: "Profile"
   href: "/profile/"
 
+- title: "Schema"
+  href: "/schema/"
+
 - title: "Archive"
   href: "/archive/"
 


### PR DESCRIPTION
- fixed rouge date in `archive/index.md`;
- added vocab link to `schema/index.md`;
- added schema menu site link to `site/_data/navbar.yml`; and
- udpated `spec-publisher` for PDF `N/A` location and schema fixes.